### PR TITLE
JP: Initial commit for auto-generated commands and arguments

### DIFF
--- a/sacrerouge/__main__.py
+++ b/sacrerouge/__main__.py
@@ -1,28 +1,34 @@
 import argparse
 
 from sacrerouge.commands import correlate, evaluate, score, setup_dataset, setup_metric
+from sacrerouge.common import command_registry
 
 
 def main():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
 
-    subcommands = [
-        correlate.CorrelateSubcommand(),
-        evaluate.EvaluateSubcommand(),
-        score.ScoreSubcommand(),
-        setup_dataset.SetupDatasetSubcommand(),
-        setup_metric.SetupMetricSubcommand()
-    ]
-    for subcommand in subcommands:
-        subcommand.add_subparser(subparsers)
+    cr = command_registry.CommandRegistry("sacrerouge")
 
-    args = parser.parse_args()
+    subcommands = [
+        correlate.CorrelateSubcommand(cr, []),##
+        evaluate.EvaluateSubcommand(cr, []),##
+        score.ScoreSubcommand(cr, []),##
+        setup_dataset.SetupDatasetSubcommand(cr, []),##
+        setup_metric.SetupMetricSubcommand(cr, [])##
+    ]
+    #for subcommand in subcommands:
+    #    subcommand.add_subparser(subparsers)
+
+    dynamic_parser = cr.create_parser()
+
+    #args = parser.parse_args()
+    args = dynamic_parser.parse_args()
+    print(args)
     if 'func' in dir(args):
         args.func(args)
     else:
         parser.print_help()
-
 
 if __name__ == '__main__':
     main()

--- a/sacrerouge/commands/correlate.py
+++ b/sacrerouge/commands/correlate.py
@@ -6,10 +6,14 @@ from collections import defaultdict
 from overrides import overrides
 from scipy.stats import kendalltau, pearsonr, spearmanr
 from typing import Any, Dict, List, Union
+import inspect
 
 from sacrerouge.commands import Subcommand
 from sacrerouge.data import Metrics, MetricsDict
 from sacrerouge.io import JsonlReader
+from sacrerouge.common import command_registry
+from sacrerouge.metrics import Metric
+from sacrerouge.metrics import *
 
 
 def load_metrics(metrics_files: List[str]) -> List[Metrics]:
@@ -176,15 +180,15 @@ def compute_correlation(metrics_jsonl_files: Union[str, List[str]],
 
 
 class CorrelateSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('correlate')
-        self.parser.add_argument('--metrics-jsonl-files', nargs='+')
-        self.parser.add_argument('--metrics', nargs=2)
-        self.parser.add_argument('--summarizer-type', choices=['all', 'reference', 'peer'])
-        self.parser.add_argument('--output-file')
-        self.parser.add_argument('--silent', action='store_true')
-        self.parser.set_defaults(func=self.run)
+    def __init__(self, cr, command_prefix):
+        super().__init__()
+        args = []
+        args.append({"name": "--metrics-jsonl-files", "nargs": "+"})
+        args.append({"name": "--metrics", "nargs": 2})
+        args.append({"name": "--summarizer-type", "choices": ["all", "reference", "peer"]})
+        args.append({"name": "--output-file"})
+        args.append({"name": "--silent", "action": "store_true"})
+        cr.register_command(command_prefix + ["correlate"], args, self.run)
 
     def run(self, args):
         metric1, metric2 = args.metrics

--- a/sacrerouge/commands/evaluate.py
+++ b/sacrerouge/commands/evaluate.py
@@ -3,6 +3,8 @@ import jsons
 import os
 from overrides import overrides
 from typing import List
+import inspect
+import sys
 
 from sacrerouge.commands import Subcommand
 from sacrerouge.common import Params
@@ -10,6 +12,8 @@ from sacrerouge.data import EvalInstance, Metrics, MetricsDict
 from sacrerouge.data.dataset_readers import DatasetReader
 from sacrerouge.io import JsonlWriter
 from sacrerouge.metrics import Metric
+from sacrerouge.data.dataset_readers import *
+from sacrerouge.metrics import *
 
 
 def load_metrics(params: Params) -> List[Metric]:
@@ -28,21 +32,70 @@ def get_initial_micro_list(instances: List[EvalInstance]) -> List[Metrics]:
 
 
 class EvaluateSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('evaluate')
-        self.parser.add_argument('config')
-        self.parser.add_argument('macro_output_json')
-        self.parser.add_argument('micro_output_jsonl')
-        self.parser.add_argument('--silent', action='store_true')
-        self.parser.add_argument('--overrides')
-        self.parser.set_defaults(func=self.run)
+    def __init__(self, cr, command_prefix):
+        super().__init__()
+        sub_prefix = command_prefix + ['evaluate']
+        dataset_reader_command_args_lookup = dict()
+        for dataset_reader_name, dataset_reader_class in DatasetReader._registry.items():
+            if issubclass(dataset_reader_class, DatasetReader):
+                argspec = inspect.getfullargspec(dataset_reader_class.__init__)
+                args = argspec.args[1:]
+                #defaults = list(argspec.defaults) if argspec.defaults is not None else None
+                annotations = argspec.annotations
+                dataset_reader_command_args = []
+                for i in range(0, len(args)):
+                    dataset_reader_command_args.append({"name": args[i]})
+                dataset_reader_command_args_lookup[dataset_reader_name] = dataset_reader_command_args
+
+        for metric_name, metric_class in Metric._registry.items():
+            if issubclass(metric_class, Metric):
+                argspec = inspect.getfullargspec(metric_class.__init__)
+                args = argspec.args[1:]
+                defaults = list(argspec.defaults)
+                defaults_dict = dict()
+                annotations = argspec.annotations
+                command_args = []
+                for i in range(0, len(args)):
+                    arg_name = args[i]
+                    if arg_name == "jackknifer":
+                        continue
+                    default_value = defaults[i]
+                    defaults_dict[arg_name] = defaults[i]
+                    command_args.append({"name": "--" + arg_name, "default": default_value})
+                command_args.append({"name": "macro_output_jsonl"})
+                command_args.append({"name": "micro_output_jsonl"})
+                command_args.append({"name": "--silent", "action": "store_true"})
+                command_args.append({"name": "--overrides"})
+                for dataset_reader_name in dataset_reader_command_args_lookup.keys():
+                    defaults_dict["metric"] = metric_name
+                    defaults_dict["dataset_reader"] = dataset_reader_name
+                    cr.register_command(sub_prefix + [metric_name, dataset_reader_name], dataset_reader_command_args_lookup[dataset_reader_name] + command_args, self.run, defaults = defaults_dict)
 
     @overrides
     def run(self, args):
-        params = Params.from_file(args.config, args.overrides)
-        dataset_reader = DatasetReader.from_params(params.pop('dataset_reader'))
-        metrics = load_metrics(params)
+        def dataset_reader_name(dataset_reader):
+            return ''.join(x.title() for x in dataset_reader.split('_')) + 'DatasetReader'
+        def metric_name(metric):
+            return ''.join(x.title() if len(x) > 2 else x.upper() for x in metric.split('_'))
+
+        def construct(cls, args):
+            print(cls)
+            argspec = inspect.getfullargspec(cls.__init__)
+            args_list = argspec.args[1:]
+            args_dict = vars(args)
+            params = dict()
+            for arg_name in args_list:
+                params[arg_name] = args_dict[arg_name]
+            print(params)
+            return cls(**params)
+
+        dataset_reader_cls_name = args.dataset_reader.replace('-', '_')
+        dataset_reader_cls = getattr(sys.modules[__name__], dataset_reader_name(dataset_reader_cls_name))
+        metric_cls_name = args.metric.replace('-', '_')
+        metric_cls = getattr(sys.modules[__name__], metric_name(metric_cls_name))
+        dataset_reader = construct(dataset_reader_cls, args)
+        metric = construct(metric_cls, args)
+        metrics = [metric]
 
         instances = dataset_reader.read()
         summaries = [instance.summary for instance in instances]

--- a/sacrerouge/commands/setup_dataset.py
+++ b/sacrerouge/commands/setup_dataset.py
@@ -8,29 +8,17 @@ from sacrerouge.datasets.multiling import multiling2011
 
 
 class SetupDatasetSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('setup-dataset')
-        subparsers = self.parser.add_subparsers()
+    def __init__(self, cr, command_prefix):
+        super().__init__()
+        sub_prefix = command_prefix + ["setup-dataset"]
 
-        subcommands = [
-            chaganty2018.Chaganty2018Subcommand(),
-            duc2005.DUC2005Subcommand(),
-            duc2006.DUC2006Subcommand(),
-            duc2007.DUC2007Subcommand(),
-            multiling2011.MultiLing2011Subcommand(),
-            tac2008.TAC2008Subcommand(),
-            tac2009.TAC2009Subcommand(),
-            tac2010.TAC2010Subcommand(),
+        self.subcommands = [
+            chaganty2018.Chaganty2018Subcommand(cr, sub_prefix),
+            duc2005.DUC2005Subcommand(cr, sub_prefix),
+            duc2006.DUC2006Subcommand(cr, sub_prefix),
+            duc2007.DUC2007Subcommand(cr, sub_prefix),
+            multiling2011.MultiLing2011Subcommand(cr, sub_prefix),
+            tac2008.TAC2008Subcommand(cr, sub_prefix),
+            tac2009.TAC2009Subcommand(cr, sub_prefix),
+            tac2010.TAC2010Subcommand(cr, sub_prefix),
         ]
-        for subcommand in subcommands:
-            subcommand.add_subparser(subparsers)
-
-        self.parser.set_defaults(func=self.run)
-
-    @overrides
-    def run(self, args):
-        if 'subfunc' in dir(args):
-            args.subfunc(args)
-        else:
-            self.parser.print_help()

--- a/sacrerouge/commands/setup_metric.py
+++ b/sacrerouge/commands/setup_metric.py
@@ -6,27 +6,15 @@ from sacrerouge.metrics import autosummeng, bewte, meteor, moverscore, simetrix,
 
 
 class SetupMetricSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('setup-metric')
-        subparsers = self.parser.add_subparsers()
+    def __init__(self, cr, command_prefix):
+        super().__init__()
+        sub_prefix = command_prefix + ["setup-metric"]
 
-        subcommands = [
-            autosummeng.AutoSummENGSetupSubcommand(),
-            bewte.BEwTESetupSubcommand(),
-            meteor.MeteorSetupSubcommand(),
-            moverscore.MoverScoreSetupSubcommand(),
-            simetrix.SIMetrixSetupSubcommand(),
-            sumqe.SumQESetupSubcommand(),
+        self.subcommands = [
+            autosummeng.AutoSummENGSetupSubcommand(cr, sub_prefix),
+            bewte.BEwTESetupSubcommand(cr, sub_prefix),
+            meteor.MeteorSetupSubcommand(cr, sub_prefix),
+            moverscore.MoverScoreSetupSubcommand(cr, sub_prefix),
+            simetrix.SIMetrixSetupSubcommand(cr, sub_prefix),
+            sumqe.SumQESetupSubcommand(cr, sub_prefix),
         ]
-        for subcommand in subcommands:
-            subcommand.add_subparser(subparsers)
-
-        self.parser.set_defaults(func=self.run)
-
-    @overrides
-    def run(self, args):
-        if 'subfunc' in dir(args):
-            args.subfunc(args)
-        else:
-            self.parser.print_help()

--- a/sacrerouge/common/_testcr.py
+++ b/sacrerouge/common/_testcr.py
@@ -1,0 +1,25 @@
+from command_registry import *
+import argparse
+
+def test_status(args):
+	print("test_status")
+	print(args)
+def test_remote_add(args):
+	print("test_remote_add")
+	print(args)
+def test_remote_remove(args):
+	print("test_remote_remove")
+	print(args)
+
+def main():
+	cr = CommandRegistry("testgit")
+	cr.register_command(["status"], [], test_status)
+	cr.register_command(["remote", "add"], ["name"], test_remote_add)
+	cr.register_command(["remote", "remove"], ["name"], test_remote_remove)
+	parser = cr.create_parser()
+	arguments = vars(parser.parse_args())
+	func = arguments['func']
+	arguments.pop('func')
+	func(arguments)
+
+main()

--- a/sacrerouge/common/command_registry.py
+++ b/sacrerouge/common/command_registry.py
@@ -1,0 +1,77 @@
+import argparse
+
+class TreeNode(object):
+	def __init__(self, title, args, children):
+		self.title = title
+		self.args = args
+		self.children = children
+		self.func = None
+		self.defaults = None
+
+	def __repr__(self):
+		return "TreeNode[title = " + repr(self.title) + ", func = " + repr(self.func) + ", defaults = " + repr(self.defaults) + ", args = " + repr(self.args) + ", children = " + repr(self.children) + "]"
+
+class CommandRegistry(object):
+	def __init__(self, root_command):
+		self.commands = dict()
+		self.functions = dict()
+		self.defaults = dict()
+		self.root_command = root_command
+
+	def register_command(self, path, args, func, defaults = None):
+		self.commands[tuple(path)] = args
+		self.functions[tuple(path)] = func
+		self.defaults[tuple(path)] = defaults
+
+	def build_command_tree(self):
+		command_tree = TreeNode(self.root_command, [], [])
+		for command_path_tuple, args in self.commands.items():
+			func = self.functions[command_path_tuple]
+			defaults = self.defaults[command_path_tuple]
+			command_path = list(command_path_tuple)
+			node = command_tree
+			for command_keyword in command_path:
+				next_node = None
+				for child in node.children:
+					if child.title == command_keyword:
+						next_node = child
+				if next_node == None:
+					next_node = TreeNode(command_keyword, [], [])
+					node.children.append(next_node)
+				node = next_node
+				if command_keyword == command_path[-1]:
+					node.args = args
+					node.func = func
+					node.defaults = defaults
+		return command_tree
+
+	def add_command_to_parser(self, node, parser):
+		if not node.children == []:
+			# subcommands
+			subparser = parser.add_subparsers()
+			for sub_command in node.children:
+				parser_inner = subparser.add_parser(sub_command.title)
+				self.add_command_to_parser(sub_command, parser_inner)
+		else:
+			default_values = node.defaults if node.defaults is not None else dict()
+			default_values["func"] = node.func
+			parser.set_defaults(**default_values) # Dictionary expansion
+			for arg in node.args:
+				#parser.add_argument(arg)
+				if 'nargs' in arg:
+					parser.add_argument(arg['name'], nargs=arg['nargs'])
+				elif 'choices' in arg:
+					parser.add_argument(arg['name'], choices=arg['choices'])
+				elif 'action' in arg:
+					parser.add_argument(arg['name'], action=arg['action'])
+				elif 'default' in arg:
+					parser.add_argument(arg['name'], nargs='?', const=arg['default'])
+				else:
+					parser.add_argument(arg['name'])
+
+	def create_parser(self):
+		command_tree = self.build_command_tree()
+		#print(repr(command_tree))
+		parser = argparse.ArgumentParser()
+		self.add_command_to_parser(command_tree, parser)
+		return parser

--- a/sacrerouge/datasets/chaganty2018/subcommand.py
+++ b/sacrerouge/datasets/chaganty2018/subcommand.py
@@ -3,14 +3,14 @@ from overrides import overrides
 
 from sacrerouge.datasets.chaganty2018 import setup
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class Chaganty2018Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('chaganty2018')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class Chaganty2018Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "chaganty2018", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/dataset_subcommand.py
+++ b/sacrerouge/datasets/dataset_subcommand.py
@@ -1,0 +1,6 @@
+from sacrerouge.commands import Subcommand
+
+class DatasetSubcommand(Subcommand):
+	def __init__(self, cr, command_prefix, command_name, args, func):
+		super().__init__()
+		cr.register_command(command_prefix + [command_name], args, func)

--- a/sacrerouge/datasets/duc_tac/duc2005/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/duc2005/subcommand.py
@@ -3,15 +3,15 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.duc2005 import metrics, task1
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class DUC2005Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('duc2005')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class DUC2005Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "duc2005", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/duc_tac/duc2006/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/duc2006/subcommand.py
@@ -3,15 +3,15 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.duc2006 import metrics, pyramids, task1
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class DUC2006Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('duc2006')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class DUC2006Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "duc2006", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/duc_tac/duc2007/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/duc2007/subcommand.py
@@ -3,15 +3,15 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.duc2007 import metrics, pyramids, tasks
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class DUC2007Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('duc2007')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class DUC2007Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "duc2007", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/duc_tac/tac2008/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/tac2008/subcommand.py
@@ -3,15 +3,15 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.tac2008 import metrics, pyramids, task1
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class TAC2008Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('tac2008')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class TAC2008Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "tac2008", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/duc_tac/tac2009/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/tac2009/subcommand.py
@@ -3,16 +3,16 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.tac2009 import metrics, pyramids, task1
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class TAC2009Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('tac2009')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
-
+class TAC2009Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "tac2009", args, self.run)
+    
     @overrides
     def run(self, args):
         task1.setup(args.data_root, args.output_dir)

--- a/sacrerouge/datasets/duc_tac/tac2010/subcommand.py
+++ b/sacrerouge/datasets/duc_tac/tac2010/subcommand.py
@@ -3,15 +3,15 @@ from overrides import overrides
 
 from sacrerouge.datasets.duc_tac.tac2010 import metrics, pyramids, task1
 from sacrerouge.commands import Subcommand
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class TAC2010Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('tac2010')
-        self.parser.add_argument('data_root')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
+class TAC2010Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "data_root"})
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "tac2010", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/datasets/multiling/multiling2011/subcommand.py
+++ b/sacrerouge/datasets/multiling/multiling2011/subcommand.py
@@ -4,15 +4,15 @@ from overrides import overrides
 from sacrerouge.datasets.multiling.multiling2011 import metrics, task
 from sacrerouge.commands import Subcommand
 from sacrerouge.common.util import download_url_to_file
+from sacrerouge.datasets.dataset_subcommand import DatasetSubcommand
 
 
-class MultiLing2011Subcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('multiling2011')
-        self.parser.add_argument('output_dir')
-        self.parser.set_defaults(subfunc=self.run)
-
+class MultiLing2011Subcommand(DatasetSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "output_dir"})
+        super().__init__(cr, command_prefix, "multiling2011", args, self.run)
+    
     def _notify_about_license(self):
         print('The MultiLing2011 dataset is distributed by the MultiLing Pilot '
               'of Text Analysis Conference 2011 under the Create Commons Attribution 3.0 '

--- a/sacrerouge/metrics/autosummeng.py
+++ b/sacrerouge/metrics/autosummeng.py
@@ -13,6 +13,8 @@ from sacrerouge.data.fields import ReferencesField, SummaryField
 from sacrerouge.data.jackknifers import ReferencesJackknifer
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
+
 
 
 @Metric.register('autosummeng')
@@ -124,11 +126,10 @@ class AutoSummENG(Metric):
         return self._run(summaries_list, references_list)
 
 
-class AutoSummENGSetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('autosummeng')
-        self.parser.set_defaults(subfunc=self.run)
+class AutoSummENGSetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        super().__init__(cr, command_prefix, "autosummeng", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/metrics/bewte.py
+++ b/sacrerouge/metrics/bewte.py
@@ -13,6 +13,7 @@ from sacrerouge.data.fields import ReferencesField, SummaryField
 from sacrerouge.data.jackknifers import ReferencesJackknifer
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
 
 
 @Metric.register('bewte')
@@ -248,11 +249,10 @@ class BEwTE(Metric):
             return metrics_lists
 
 
-class BEwTESetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('bewte')
-        self.parser.set_defaults(subfunc=self.run)
+class BEwTESetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        super().__init__(cr, command_prefix, "bewte", args, self.run)
 
     def _edit_pom(self, file_path: str) -> None:
         # We need to edit the pom.xml file to add options to run the main classes

--- a/sacrerouge/metrics/meteor.py
+++ b/sacrerouge/metrics/meteor.py
@@ -11,6 +11,7 @@ from sacrerouge.data.fields import ReferencesField, SummaryField
 from sacrerouge.data.jackknifers import ReferencesJackknifer
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
 
 
 @Metric.register('meteor')
@@ -125,11 +126,10 @@ class Meteor(Metric):
         return macro_metrics, micro_metrics_list
 
 
-class MeteorSetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('meteor')
-        self.parser.set_defaults(subfunc=self.run)
+class MeteorSetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        super().__init__(cr, command_prefix, "meteor", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/metrics/metric_subcommand.py
+++ b/sacrerouge/metrics/metric_subcommand.py
@@ -1,0 +1,6 @@
+from sacrerouge.commands import Subcommand
+
+class MetricSubcommand(Subcommand):
+	def __init__(self, cr, command_prefix, command_name, args, func):
+		super().__init__()
+		cr.register_command(command_prefix + [command_name], args, func)

--- a/sacrerouge/metrics/moverscore.py
+++ b/sacrerouge/metrics/moverscore.py
@@ -12,6 +12,7 @@ from sacrerouge.data.fields import ReferencesField, SummaryField
 from sacrerouge.data.jackknifers import ReferencesJackknifer
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
 
 MOVERSCORE_EXISTS = False
 
@@ -111,11 +112,10 @@ except ImportError:
             raise NotImplementedError('Error: "moverscore" python package is not installed')
 
 
-class MoverScoreSetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('moverscore')
-        self.parser.set_defaults(subfunc=self.run)
+class MoverScoreSetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        super().__init__(cr, command_prefix, "moverscore", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/metrics/simetrix.py
+++ b/sacrerouge/metrics/simetrix.py
@@ -11,6 +11,7 @@ from sacrerouge.data import MetricsDict
 from sacrerouge.data.fields import DocumentsField, SummaryField
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
 
 
 @Metric.register('simetrix')
@@ -158,11 +159,10 @@ class SIMetrix(Metric):
         return macro_metrics, micro_metrics_list
 
 
-class SIMetrixSetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('simetrix')
-        self.parser.set_defaults(subfunc=self.run)
+class SIMetrixSetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        super().__init__(cr, command_prefix, "simetrix", args, self.run)
 
     @overrides
     def run(self, args):

--- a/sacrerouge/metrics/sumqe.py
+++ b/sacrerouge/metrics/sumqe.py
@@ -12,6 +12,7 @@ from sacrerouge.data import MetricsDict
 from sacrerouge.data.fields import SummaryField
 from sacrerouge.data.types import SummaryType
 from sacrerouge.metrics import Metric
+from sacrerouge.metrics.metric_subcommand import MetricSubcommand
 
 
 @Metric.register('sum-qe')
@@ -86,14 +87,13 @@ class SumQE(Metric):
         return self._run(summaries_list)
 
 
-class SumQESetupSubcommand(Subcommand):
-    @overrides
-    def add_subparser(self, parser: argparse._SubParsersAction):
-        self.parser = parser.add_parser('sum-qe')
-        self.parser.add_argument('--download-2005-2006-model', action='store_true')
-        self.parser.add_argument('--download-2005-2007-model', action='store_true')
-        self.parser.add_argument('--download-2006-2007-model', action='store_true')
-        self.parser.set_defaults(subfunc=self.run)
+class SumQESetupSubcommand(MetricSubcommand):
+    def __init__(self, cr, command_prefix):
+        args = []
+        args.append({"name": "--download-2005-2006-model", "action": "store_true"})
+        args.append({"name": "--download-2005-2007-model", "action": "store_true"})
+        args.append({"name": "--download-2006-2007-model", "action": "store_true"})
+        super().__init__(cr, command_prefix, "sum-qe", args, self.run)
 
     @overrides
     def run(self, args):


### PR DESCRIPTION
Most of the commands are auto generated, and except for `sacrerouge correlate` all of the arguments are passed on the command line with the arguments/defaults inferred from the class constructors. All of the commands can still parse the parameters, although some of the code may need to be cleaned up.