### PR TITLE
JP: Made subcommands registrable

### DIFF
--- a/sacrerouge/commands/correlate.py
+++ b/sacrerouge/commands/correlate.py
@@ -174,7 +174,7 @@ def compute_correlation(metrics_jsonl_files: Union[str, List[str]],
     }
     return results
 
-
+@Subcommand.register('correlate')
 class CorrelateSubcommand(Subcommand):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction):

--- a/sacrerouge/commands/evaluate.py
+++ b/sacrerouge/commands/evaluate.py
@@ -27,6 +27,7 @@ def get_initial_micro_list(instances: List[EvalInstance]) -> List[Metrics]:
     return micro_list
 
 
+@Subcommand.register('evaluate')
 class EvaluateSubcommand(Subcommand):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction):

--- a/sacrerouge/commands/score.py
+++ b/sacrerouge/commands/score.py
@@ -101,6 +101,7 @@ def score_instances(instances: List[EvalInstance], metrics: List[Metric]) -> Dic
     return metrics_dicts
 
 
+@Subcommand.register('score')
 class ScoreSubcommand(Subcommand):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction):

--- a/sacrerouge/commands/setup_dataset.py
+++ b/sacrerouge/commands/setup_dataset.py
@@ -7,6 +7,7 @@ from sacrerouge.datasets.duc_tac import duc2005, duc2006, duc2007, tac2008, tac2
 from sacrerouge.datasets.multiling import multiling2011
 
 
+@Subcommand.register('setup-dataset')
 class SetupDatasetSubcommand(Subcommand):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction):

--- a/sacrerouge/commands/setup_metric.py
+++ b/sacrerouge/commands/setup_metric.py
@@ -5,6 +5,7 @@ from sacrerouge.commands import Subcommand
 from sacrerouge.metrics import autosummeng, bewte, meteor, moverscore, simetrix, sumqe
 
 
+@Subcommand.register('setup-metric')
 class SetupMetricSubcommand(Subcommand):
     @overrides
     def add_subparser(self, parser: argparse._SubParsersAction):

--- a/sacrerouge/commands/subcommand.py
+++ b/sacrerouge/commands/subcommand.py
@@ -1,7 +1,8 @@
 import argparse
 
+from sacrerouge.common import Registrable
 
-class Subcommand(object):
+class Subcommand(Registrable):
     def add_subparser(self, parser: argparse._SubParsersAction) -> None:
         raise NotImplementedError
 

--- a/sacrerouge/common/registrable.py
+++ b/sacrerouge/common/registrable.py
@@ -5,10 +5,12 @@ from sacrerouge.common import FromParams
 
 class Registrable(FromParams):
     _registry: Dict[str, Type] = {}
+    _parents: Dict[str, str] = {}
 
     @classmethod
-    def register(cls: Type, name: str):
+    def register(cls: Type, name: str, parent: str = None):
         def _register(subclass: Type):
             cls._registry[name] = subclass
+            cls._parents[name] = parent
             return subclass
         return _register


### PR DESCRIPTION
I added an optional parameter to Registrable.register() and made Subcommand a subclass of Registrable. Example usage: `@Subcommand.register('this-command', 'parent-command')`

Subcommand._registry and Subcommand._parents could be used to generate the argparse parser.