### PR TITLE
Removing stderr exception

### DIFF
--- a/sacrerouge/metrics/meteor.py
+++ b/sacrerouge/metrics/meteor.py
@@ -100,9 +100,7 @@ class Meteor(ReferenceBasedMetric):
 
             logger.info(f'Running METEOR command: "{command}"')
             process = Popen(command, stdout=PIPE, stderr=PIPE)
-            stdout, stderr = process.communicate()
-            if stderr:
-                raise Exception(f'Meteor failed with stderr: {stderr.decode()}')
+            stdout, _ = process.communicate()
 
             final_score, individual_scores = self._parse_meteor_stdout(stdout.decode())
 


### PR DESCRIPTION
For some reason, there is a new stderr output from Java on the Github unit tests which appears to not be a meaningful error (see [here](https://github.com/danieldeutsch/sacrerouge/actions/runs/220281926)). Previously, this threw an exception. This PR removes that exception