### PR TITLE
Fixing overrides version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Added an exception with an error message if PyrEval is used with a single reference summary.
 
+### Fixed
+- Fix the `overrides` package to version 3.1.0 to fix a bug that was caused in the `Params` class in `overrides` version 6.0.0
+
 ## [v0.2.0](https://github.com/danieldeutsch/sacrerouge/releases/tag/0.2.0) - 2021-03-26
 ### Added
 - Added the annotations collected by [Bhandari et al., (2020)](https://www.aclweb.org/anthology/2020.emnlp-main.751/).

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jsons
 lxml
 nltk
 numpy
-overrides
+overrides==3.1.0
 pytest
 requests
 scipy>=1.5.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
         'lxml',
         'nltk',
         'numpy',
-        'overrides',
+        'overrides==3.1.0',
         'pytest',
         'requests',
         'scipy>=1.5.2',


### PR DESCRIPTION
This change fixes a bug that was caused by `overrides==6.0.0`:

```
Traceback (most recent call last):
  File "/usr/local/bin/sacrerouge", line 5, in <module>
    from sacrerouge.__main__ import main
  File "/usr/local/lib/python3.7/dist-packages/sacrerouge/__init__.py", line 1, in <module>
    from sacrerouge.arguments import build_argument_parser
  File "/usr/local/lib/python3.7/dist-packages/sacrerouge/arguments.py", line 3, in <module>
    from sacrerouge.common import Registrable
  File "/usr/local/lib/python3.7/dist-packages/sacrerouge/common/__init__.py", line 5, in <module>
    from sacrerouge.common.params import Params
  File "/usr/local/lib/python3.7/dist-packages/sacrerouge/common/params.py", line 190, in <module>
    class Params(MutableMapping):
  File "/usr/local/lib/python3.7/dist-packages/sacrerouge/common/params.py", line 223, in Params
    def pop(self, key: str, default: Any = DEFAULT, keep_as_dict: bool = False) -> Any:
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 88, in overrides
    return _overrides(method, check_signature, check_at_runtime)
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 114, in _overrides
    _validate_method(method, super_class, check_signature)
  File "/usr/local/lib/python3.7/dist-packages/overrides/overrides.py", line 135, in _validate_method
    ensure_signature_is_compatible(super_method, method, is_static)
  File "/usr/local/lib/python3.7/dist-packages/overrides/signature.py", line 87, in ensure_signature_is_compatible
    super_sig, sub_sig, super_type_hints, sub_type_hints, is_static, method_name
  File "/usr/local/lib/python3.7/dist-packages/overrides/signature.py", line 213, in ensure_all_positional_args_defined_in_sub
    f"`{method_name}: {sub_param.name} must be a supertype of `{super_param.annotation}` but is `{sub_param.annotation}`"
TypeError: `Params.pop: key must be a supertype of `<class 'inspect._empty'>` but is `<class 'str'>`
```

The fix locks `overrides==3.1.0`, which is what AllenNLP also does.